### PR TITLE
Regex updates

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
-const EP_REGEX = /^(?<title>.+)[. ](?<season>S\d\d)(?<episode>E\d\d)/i;
-const SEASON_REGEX = /^(?<title>.+)[. ](?<season>S\d\d)(?!E\d\d)/i;
+const EP_REGEX = /^(?<title>.+)[. ](?<season>S\d+)(?<episode>E\d+)/i;
+const SEASON_REGEX = /^(?<title>.+)[. ](?<season>S\d+)(?!E\d+)(?<seasonmax>\s*\-\s*S?\d+)?/i;
 const MOVIE_REGEX = /^(?<title>.+)[. ](?<year>\d{4})/i;
 
 const EXTENSIONS = ["mkv", "mp4", "avi"];

--- a/src/preFilter.js
+++ b/src/preFilter.js
@@ -33,13 +33,6 @@ function filterByContent(info) {
 		return false;
 	}
 
-	const cb = (file) => file.path.split(path.sep).length <= 2;
-	const notNested = files.every(cb);
-	if (!notNested) {
-		logReason("the directory tree is more than 2 levels deep");
-		return false;
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
Some shows may have over 100 episodes in a season, current implementation won't handle that. Also season regex won't catch situations like S01-10, it'll see only S01. For examples see:
https://regex101.com/r/HCc47S/2
https://regex101.com/r/hkMIfw/1