### PR TITLE
Write custom path checking using original parse-torrent library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"bencode": "^2.0.1",
 				"chalk": "^4.1.0",
 				"commander": "^7.0.0",
-				"parse-torrent": "https://github.com/mmgoodnow/parse-torrent/archive/68aadd378c1810d5939d2edf16c1111487611400.tar.gz",
+				"parse-torrent": "^9.1.3",
 				"simple-get": "^4.0.0",
 				"xmlrpc": "^1.3.2"
 			},
@@ -605,7 +605,21 @@
 		"node_modules/blob-to-buffer": {
 			"version": "1.2.9",
 			"resolved": "https://registry.npmjs.org/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz",
-			"integrity": "sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA=="
+			"integrity": "sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/boxen": {
 			"version": "5.0.0",
@@ -1691,6 +1705,9 @@
 			"integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-stream": {
@@ -3349,6 +3366,20 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/magnet-uri/-/magnet-uri-6.1.0.tgz",
 			"integrity": "sha512-731qLviHaqN/Ni96wm6gNKuvoip+QHWTznjHNz/4qDlsHh3/CWJoL8fZ18IIRhGJgnWoKJp8RVE5lZvQ60Khhw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
 			"dependencies": {
 				"bep53-range": "^1.0.0",
 				"thirty-two": "^1.0.2"
@@ -4372,8 +4403,23 @@
 			}
 		},
 		"node_modules/parse-torrent": {
-			"resolved": "https://github.com/mmgoodnow/parse-torrent/archive/68aadd378c1810d5939d2edf16c1111487611400.tar.gz",
-			"integrity": "sha512-8GpMyro3N0vecDJ8UOC9X6gSoXfMKFjuttjzXjl7jrTYU0n7CtkVB1lFNfX7xLIlbYb4VtWv+t/bnpnJQlGD1g==",
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.3.tgz",
+			"integrity": "sha512-/Yr951CvJM8S6TjMaqrsmMxeQEAjDeCX+MZ3hGXXc7DG2wqzp/rzOsHtDzIVqN6NsFRCqy6wYLF/W7Sgvq7bXw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
 			"dependencies": {
 				"bencode": "^2.0.1",
 				"blob-to-buffer": "^1.2.9",
@@ -4950,12 +4996,12 @@
 			}
 		},
 		"node_modules/simple-sha1": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.0.1.tgz",
-			"integrity": "sha512-q7ehqWfHc1VhOm7sW099YDZ4I0yYX7rqyhqqhHV1IYeUTjPOhHyD3mXvv8k2P+rO7+7c8R4/D+8ffzC9BE7Cqg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.1.0.tgz",
+			"integrity": "sha512-ArTptMRC1v08H8ihPD6l0wesKvMfF9e8XL5rIHPanI7kGOsSsbY514MwVu6X1PITHCTB2F08zB7cyEbfc4wQjg==",
 			"dependencies": {
-				"queue-microtask": "^1.1.2",
-				"rusha": "^0.8.1"
+				"queue-microtask": "^1.2.2",
+				"rusha": "^0.8.13"
 			}
 		},
 		"node_modules/slash": {
@@ -9056,8 +9102,9 @@
 			}
 		},
 		"parse-torrent": {
-			"version": "https://github.com/mmgoodnow/parse-torrent/archive/68aadd378c1810d5939d2edf16c1111487611400.tar.gz",
-			"integrity": "sha512-8GpMyro3N0vecDJ8UOC9X6gSoXfMKFjuttjzXjl7jrTYU0n7CtkVB1lFNfX7xLIlbYb4VtWv+t/bnpnJQlGD1g==",
+			"version": "9.1.3",
+			"resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.3.tgz",
+			"integrity": "sha512-/Yr951CvJM8S6TjMaqrsmMxeQEAjDeCX+MZ3hGXXc7DG2wqzp/rzOsHtDzIVqN6NsFRCqy6wYLF/W7Sgvq7bXw==",
 			"requires": {
 				"bencode": "^2.0.1",
 				"blob-to-buffer": "^1.2.9",
@@ -9507,12 +9554,12 @@
 			}
 		},
 		"simple-sha1": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.0.1.tgz",
-			"integrity": "sha512-q7ehqWfHc1VhOm7sW099YDZ4I0yYX7rqyhqqhHV1IYeUTjPOhHyD3mXvv8k2P+rO7+7c8R4/D+8ffzC9BE7Cqg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-3.1.0.tgz",
+			"integrity": "sha512-ArTptMRC1v08H8ihPD6l0wesKvMfF9e8XL5rIHPanI7kGOsSsbY514MwVu6X1PITHCTB2F08zB7cyEbfc4wQjg==",
 			"requires": {
-				"queue-microtask": "^1.1.2",
-				"rusha": "^0.8.1"
+				"queue-microtask": "^1.2.2",
+				"rusha": "^0.8.13"
 			}
 		},
 		"slash": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"bencode": "^2.0.1",
 		"chalk": "^4.1.0",
 		"commander": "^7.0.0",
-		"parse-torrent": "https://github.com/mmgoodnow/parse-torrent/archive/68aadd378c1810d5939d2edf16c1111487611400.tar.gz",
+		"parse-torrent": "^9.1.3",
 		"simple-get": "^4.0.0",
 		"xmlrpc": "^1.3.2"
 	},


### PR DESCRIPTION
This is the permanent fix for #46. It was fixed temporarily in https://github.com/mmgoodnow/cross-seed/commit/8385937bb39b57ed347f902037790b446a2be8d4 but that involved forking the parse-torrent package and referencing that fork in cross-seed's package.json. I was able to implement a custom solution using the original version of parse-torrent which is preferable because now I don't have to maintain the fork.

@Drazzlib08 I'm going to merge this in and cut a new release; please let me know if that bug comes back or if you see anything else that's funky.