### PR TITLE
[FEATURE] - Allow daemon mode to search for torrents via hash

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -12,6 +12,7 @@ import { Searchee } from "./searchee";
 import {
 	getInfoHashesToExclude,
 	getTorrentByName,
+	getTorrentByHash,
 	loadTorrentDirLight,
 	saveTorrentFile,
 } from "./torrent";
@@ -140,6 +141,15 @@ export async function searchForSingleTorrentByName(
 	name: string
 ): Promise<number> {
 	const meta = await getTorrentByName(name);
+	const hashesToExclude = getInfoHashesToExclude();
+	if (!filterByContent(meta)) return null;
+	return findOnOtherSites(meta, hashesToExclude);
+}
+
+export async function searchForSingleTorrentByHash(
+	hash: string
+): Promise<number> {
+	const meta = await getTorrentByHash(hash);
 	const hashesToExclude = getInfoHashesToExclude();
 	if (!filterByContent(meta)) return null;
 	return findOnOtherSites(meta, hashesToExclude);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,9 +10,9 @@ import { filterByContent, filterDupes, filterTimestamps } from "./preFilter";
 import { getRuntimeConfig } from "./runtimeConfig";
 import { Searchee } from "./searchee";
 import {
-	TorrentInfo,
+	TorrentLocator,
 	getInfoHashesToExclude,
-	getTorrentByNameOrHash,
+	getTorrentByCriteria,
 	loadTorrentDirLight,
 	saveTorrentFile,
 } from "./torrent";
@@ -137,10 +137,10 @@ async function findMatchesBatch(
 	return totalFound;
 }
 
-export async function searchForSingleTorrentByNameOrHash(
-	torrent: TorrentInfo
+export async function searchForLocalTorrentByCriteria(
+	criteria: TorrentLocator
 ): Promise<number> {
-	const meta = await getTorrentByNameOrHash(torrent);
+	const meta = await getTorrentByCriteria(criteria);
 	const hashesToExclude = getInfoHashesToExclude();
 	if (!filterByContent(meta)) return null;
 	return findOnOtherSites(meta, hashesToExclude);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -10,9 +10,9 @@ import { filterByContent, filterDupes, filterTimestamps } from "./preFilter";
 import { getRuntimeConfig } from "./runtimeConfig";
 import { Searchee } from "./searchee";
 import {
+	TorrentInfo,
 	getInfoHashesToExclude,
-	getTorrentByName,
-	getTorrentByHash,
+	getTorrentByNameOrHash,
 	loadTorrentDirLight,
 	saveTorrentFile,
 } from "./torrent";
@@ -137,19 +137,10 @@ async function findMatchesBatch(
 	return totalFound;
 }
 
-export async function searchForSingleTorrentByName(
-	name: string
+export async function searchForSingleTorrentByNameOrHash(
+	torrent: TorrentInfo
 ): Promise<number> {
-	const meta = await getTorrentByName(name);
-	const hashesToExclude = getInfoHashesToExclude();
-	if (!filterByContent(meta)) return null;
-	return findOnOtherSites(meta, hashesToExclude);
-}
-
-export async function searchForSingleTorrentByHash(
-	hash: string
-): Promise<number> {
-	const meta = await getTorrentByHash(hash);
+	const meta = await getTorrentByNameOrHash(torrent);
 	const hashesToExclude = getInfoHashesToExclude();
 	if (!filterByContent(meta)) return null;
 	return findOnOtherSites(meta, hashesToExclude);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,12 @@
 import fs from "fs";
 import http from "http";
 import qs from "querystring";
+import { inspect } from "util";
 import { Label, logger } from "./logger";
 import { searchForLocalTorrentByCriteria } from "./pipeline";
 import { getRuntimeConfig } from "./runtimeConfig";
 import { TorrentLocator } from "./torrent";
-import { inspect } from "util";
+
 function getData(req) {
 	return new Promise((resolve) => {
 		const chunks = [];

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -156,3 +156,16 @@ export async function getTorrentByName(name: string): Promise<Metafile> {
 	}
 	return parseTorrentFromFilename(findResult.filepath);
 }
+
+export async function getTorrentByHash(hash: string): Promise<Metafile> {
+	await indexNewTorrents();
+	const findResult = db
+		.get(INDEXED_TORRENTS)
+		.value()
+		.find((e) => e.infoHash === hash);
+	if (findResult === undefined) {
+		const message = `could not find a torrent with the hash ${hash}`;
+		throw new Error(message);
+	}
+	return parseTorrentFromFilename(findResult.filepath);
+}

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -10,7 +10,7 @@ import { getRuntimeConfig } from "./runtimeConfig";
 import { createSearcheeFromTorrentFile, Searchee } from "./searchee";
 import { ok, stripExtension } from "./utils";
 
-export interface TorrentInfo {
+export interface TorrentLocator {
 	infoHash?: string;
 	name?: string;
 }
@@ -149,22 +149,14 @@ export async function loadTorrentDirLight(): Promise<Searchee[]> {
 	).then((searcheeResults) => searcheeResults.filter(ok));
 }
 
-export async function getTorrentByNameOrHash(
-	torrentInfo: TorrentInfo
+export async function getTorrentByCriteria(
+	criteria: TorrentLocator
 ): Promise<Metafile> {
 	await indexNewTorrents();
 
-	const criteria = torrentInfo?.infoHash
-		? torrentInfo?.infoHash
-		: torrentInfo?.name;
-	const property = torrentInfo?.infoHash ? "infoHash" : "name";
-
-	const findResult = db
-		.get(INDEXED_TORRENTS)
-		.value()
-		.find((e) => e[property] === criteria);
+	const findResult = db.get(INDEXED_TORRENTS).find(criteria).value();
 	if (findResult === undefined) {
-		const message = `could not find a torrent with the name ${criteria}`;
+		const message = `could not find a torrent with the criteria`;
 		throw new Error(message);
 	}
 	return parseTorrentFromFilename(findResult.filepath);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -2,6 +2,7 @@ import fs, { promises as fsPromises } from "fs";
 import parseTorrent, { Metafile } from "parse-torrent";
 import path from "path";
 import { concat } from "simple-get";
+import { inspect } from "util";
 import { INDEXED_TORRENTS } from "./constants";
 import db from "./db";
 import { CrossSeedError } from "./errors";
@@ -156,7 +157,9 @@ export async function getTorrentByCriteria(
 
 	const findResult = db.get(INDEXED_TORRENTS).find(criteria).value();
 	if (findResult === undefined) {
-		const message = `could not find a torrent with the criteria`;
+		const message = `could not find a torrent with the criteria ${inspect(
+			criteria
+		)}`;
 		throw new Error(message);
 	}
 	return parseTorrentFromFilename(findResult.filepath);


### PR DESCRIPTION
## Ready State: Yes

This pull request is related to the following Github issue: 

* #118

### Requirements & Dependencies

* None

### Deployment Instructions

* Merge code

### Usage/Test Instructions

- [ ] Run the daemon mode
- [ ] Make a curl request to the daemon passing a `hash` property in the JSON. eg: `curl -XPOST http://$CROSS_SEED_HOST:2468/api/webhook -H 'Content-Type: application/json' --data '{"hash": "$INFO_HASH"}'` - where `$CROSS_SEED_HOST` is the domain of cross seed and `$INFO_HASH` is the hash of the torrent.