### PR TITLE
Fix bug when using an empty array to represent all trackers

### DIFF
--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -28,8 +28,7 @@ function fallback(...args) {
 }
 
 function processOptions(options) {
-	options.trackers =
-		options.trackers && options.trackers.split(",").filter((e) => e !== "");
+	options.trackers = options.trackers?.split(",").filter((e) => e !== "");
 	return options;
 }
 
@@ -53,10 +52,7 @@ async function run() {
 			.requiredOption(
 				"-t, --trackers <tracker1>,<tracker2>",
 				"Comma-separated list of Jackett tracker ids to search  (Tracker ids can be found in their Torznab feed paths)",
-				fallback(
-					fileConfig.trackers && fileConfig.trackers.join(","),
-					""
-				)
+				fallback(fileConfig.trackers?.join(","), "")
 			)
 			.requiredOption(
 				"-i, --torrent-dir <dir>",

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -21,7 +21,7 @@ export async function doStartupValidation(): Promise<void> {
 	await Promise.all<void>(
 		[
 			validateJackettApi(),
-			downloadClient && downloadClient.validateConfig(),
+			downloadClient?.validateConfig(),
 			validateTorrentDir(),
 		].filter(Boolean)
 	);

--- a/src/torrent.ts
+++ b/src/torrent.ts
@@ -43,8 +43,7 @@ export async function parseTorrentFromURL(url: string): Promise<Metafile> {
 		if (
 			response.statusCode >= 300 &&
 			response.statusCode < 400 &&
-			response.headers.location &&
-			response.headers.location.startsWith("magnet:")
+			response.headers.location?.startsWith("magnet:")
 		) {
 			logger.error(`Unsupported: magnet link detected at ${url}`);
 			return null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"outDir": "./dist",
 		"allowJs": true,
-		"target": "es2020",
+		"target": "es2019",
 		"module": "CommonJS",
 		"esModuleInterop": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
`trackers: []` in the fileConfig was casting out to string as `""` after a call to `.join("'")`, which is falsy. When I added notifications support I used the shared options function to make the test-notification command, but trackers are irrelevant, and I added what I thought was a nullish check to allow the user to silently pass no trackers but it was catching said falsy empty string. 

Solved by enabling optional chaining