### PR TITLE
Arbitrary Torznab support

### DIFF
--- a/.idea/dictionaries/mmgoodnow.xml
+++ b/.idea/dictionaries/mmgoodnow.xml
@@ -4,6 +4,7 @@
       <w>bencode</w>
       <w>caronc</w>
       <w>jackett</w>
+      <w>jsified</w>
       <w>qbittorrent</w>
       <w>rtorrent</w>
       <w>savepath</w>

--- a/.idea/dictionaries/mmgoodnow.xml
+++ b/.idea/dictionaries/mmgoodnow.xml
@@ -10,6 +10,7 @@
       <w>searchee</w>
       <w>searchees</w>
       <w>seedable</w>
+      <w>torznab</w>
       <w>xmlrpc</w>
     </words>
   </dictionary>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ delivery into your client.
 ## Requirements
 
 -   [Node 14+](https://nodejs.org/en/download)
--   [Jackett](https://github.com/Jackett/Jackett)
+-   Any number of indexers that support Torznab (use Jackett or Prowlarr to
+    help)
 
 It will work on Mac and on Linux; I haven't tested it on Windows but it should
 work there too.
@@ -37,13 +38,12 @@ Here's an example invocation:
 
 ```shell script
 npx cross-seed search \
-  --jackett-server-url http://localhost:9117/jackett \
-  --jackett-api-key JACKETT_API_KEY \
+  --torznab http://localhost:9696/prowlarr/1/api?apikey=a1b2c3d4e5f6 \
   --torrent-dir /home/rtorrent/.session \
   --output-dir /tmp/torrents
 ```
 
-You either need to give it a lot of command-line arguments or create a
+You either need to give it a few command-line arguments or create a
 [configuration file](https://github.com/mmgoodnow/cross-seed/wiki/Configuration-file).
 
 ```text
@@ -53,9 +53,10 @@ Search for cross-seeds
 
 
 Options:
-  -u, --jackett-server-url <url>        Your Jackett server url
-  -k, --jackett-api-key <key>           Your Jackett API key
-  -t, --trackers <tracker1>,<tracker2>  Comma-separated list of Jackett tracker ids to search (Tracker ids can be found in their Torznab feed paths)
+  -u, --jackett-server-url <url>        DEPRECATED: Your Jackett server url
+  -k, --jackett-api-key <key>           DEPRECATED: Your Jackett API key
+  -t, --trackers <tracker1>,<tracker2>  DEPRECATED: Comma-separated list of Jackett tracker ids to search (Tracker ids can be found in their Torznab feed paths)
+  -T, --torznab <urls...>               Torznab urls with apikey included (separated by spaces)
   -i, --torrent-dir <dir>               Directory with torrent files
   -s, --output-dir <dir>                Directory to save results in
   -a, --search-all                      Search for all torrents regardless of their contents (default: false)
@@ -99,14 +100,14 @@ npm uninstall -g cross-seed
 npm install -g cross-seed
 ```
 
-## Daemon mode (beta, rTorrent only, Docker recommended)
+## Daemon mode (Docker recommended)
 
 `cross-seed` supports a daemon mode, wherein the app is always running, and you
 can trigger an HTTP request to search for cross-seeds of a specific torrent. See
 more info in the
 [wiki page](https://github.com/mmgoodnow/cross-seed/wiki/Daemon-Mode).
 
-## Direct client injection (alpha, rTorrent and qBittorrent only)
+## Direct client injection
 
 As mentioned above, `cross-seed` can inject the torrents it finds directly into
 your torrent client. See more info in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"simple-get": "^4.0.0",
 				"winston": "^3.3.3",
 				"winston-daily-rotate-file": "^4.5.5",
+				"xml2js": "^0.4.23",
 				"xmlrpc": "^1.3.2"
 			},
 			"bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
 				"node-fetch": "^3.1.0",
 				"parse-torrent": "^9.1.3",
 				"rimraf": "^3.0.2",
-				"rss-parser": "^3.12.0",
 				"simple-get": "^4.0.0",
 				"winston": "^3.3.3",
 				"winston-daily-rotate-file": "^4.5.5",
@@ -887,14 +886,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2331,15 +2322,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rss-parser": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
-			"integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
-			"dependencies": {
-				"entities": "^2.0.3",
-				"xml2js": "^0.4.19"
-			}
-		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3535,11 +3517,6 @@
 				"ansi-colors": "^4.1.1"
 			}
 		},
-		"entities": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4537,15 +4514,6 @@
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"rss-parser": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
-			"integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
-			"requires": {
-				"entities": "^2.0.3",
-				"xml2js": "^0.4.19"
 			}
 		},
 		"run-parallel": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 			"devDependencies": {
 				"@types/bencode": "^2.0.1",
 				"@types/lowdb": "^1.0.9",
+				"@types/xml2js": "^0.4.9",
 				"@types/xmlrpc": "^1.3.6",
 				"@typescript-eslint/eslint-plugin": "^5.8.1",
 				"@typescript-eslint/parser": "^5.8.1",
@@ -173,6 +174,15 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
+		},
+		"node_modules/@types/xml2js": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
+			"integrity": "sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/xmlrpc": {
 			"version": "1.3.7",
@@ -3025,6 +3035,15 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.5.tgz",
 			"integrity": "sha512-w3mrvNXLeDYV1GKTZorGJQivK6XLCoGwpnyJFbJVK/aTBQUxOCaa/GlFAAN3OTDFcb7h5tiFG+YXCO2By+riZw==",
 			"dev": true
+		},
+		"@types/xml2js": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.9.tgz",
+			"integrity": "sha512-CHiCKIihl1pychwR2RNX5mAYmJDACgFVCMT5OArMaO3erzwXVcBqPcusr+Vl8yeeXukxZqtF8mZioqX+mpjjdw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/xmlrpc": {
 			"version": "1.3.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"node-fetch": "^3.1.0",
 				"parse-torrent": "^9.1.3",
 				"rimraf": "^3.0.2",
+				"rss-parser": "^3.12.0",
 				"simple-get": "^4.0.0",
 				"winston": "^3.3.3",
 				"winston-daily-rotate-file": "^4.5.5",
@@ -875,6 +876,14 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/escape-string-regexp": {
@@ -2311,6 +2320,15 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/rss-parser": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
+			"integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
+			"dependencies": {
+				"entities": "^2.0.3",
+				"xml2js": "^0.4.19"
+			}
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2834,6 +2852,26 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"node_modules/xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xml2js/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
 		"node_modules/xmlbuilder": {
 			"version": "8.2.2",
@@ -3476,6 +3514,11 @@
 			"requires": {
 				"ansi-colors": "^4.1.1"
 			}
+		},
+		"entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -4476,6 +4519,15 @@
 				"glob": "^7.1.3"
 			}
 		},
+		"rss-parser": {
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
+			"integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
+			"requires": {
+				"entities": "^2.0.3",
+				"xml2js": "^0.4.19"
+			}
+		},
 		"run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4835,6 +4887,22 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"dependencies": {
+				"xmlbuilder": {
+					"version": "11.0.1",
+					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+					"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+				}
+			}
 		},
 		"xmlbuilder": {
 			"version": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"node-fetch": "^3.1.0",
 		"parse-torrent": "^9.1.3",
 		"rimraf": "^3.0.2",
+		"rss-parser": "^3.12.0",
 		"simple-get": "^4.0.0",
 		"winston": "^3.3.3",
 		"winston-daily-rotate-file": "^4.5.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"simple-get": "^4.0.0",
 		"winston": "^3.3.3",
 		"winston-daily-rotate-file": "^4.5.5",
+		"xml2js": "^0.4.23",
 		"xmlrpc": "^1.3.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	"devDependencies": {
 		"@types/bencode": "^2.0.1",
 		"@types/lowdb": "^1.0.9",
+		"@types/xml2js": "^0.4.9",
 		"@types/xmlrpc": "^1.3.6",
 		"@typescript-eslint/eslint-plugin": "^5.8.1",
 		"@typescript-eslint/parser": "^5.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 		"node-fetch": "^3.1.0",
 		"parse-torrent": "^9.1.3",
 		"rimraf": "^3.0.2",
-		"rss-parser": "^3.12.0",
 		"simple-get": "^4.0.0",
 		"winston": "^3.3.3",
 		"winston-daily-rotate-file": "^4.5.5",

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -44,18 +44,23 @@ function createCommandWithSharedOptions(name, description) {
 		.description(description)
 		.requiredOption(
 			"-u, --jackett-server-url <url>",
-			"Your Jackett server url",
+			"DEPRECATED: Your Jackett server url",
 			fileConfig.jackettServerUrl
 		)
 		.requiredOption(
 			"-k, --jackett-api-key <key>",
-			"Your Jackett API key",
+			"DEPRECATED: Your Jackett API key",
 			fileConfig.jackettApiKey
 		)
 		.requiredOption(
 			"-t, --trackers <tracker1>,<tracker2>",
-			"Comma-separated list of Jackett tracker ids to search  (Tracker ids can be found in their Torznab feed paths)",
+			"DEPRECATED: Comma-separated list of Jackett tracker ids to search  (Tracker ids can be found in their Torznab feed paths)",
 			fallback(fileConfig.trackers?.join(","), "")
+		)
+		.requiredOption(
+			"-T, --torznab <urls...>",
+			"Torznab urls with apikey included (separated by spaces)",
+			fallback(fileConfig.torznab)
 		)
 		.requiredOption(
 			"-i, --torrent-dir <dir>",
@@ -149,8 +154,7 @@ program
 		fileConfig.notificationWebhookUrl
 	)
 	.action((options) => {
-		const runtimeConfig = processOptions(options);
-		setRuntimeConfig(runtimeConfig);
+		setRuntimeConfig(options);
 		initializeLogger();
 		initializePushNotifier();
 		sendTestNotification();

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -42,22 +42,22 @@ function createCommandWithSharedOptions(name, description) {
 	return program
 		.command(name)
 		.description(description)
-		.requiredOption(
+		.option(
 			"-u, --jackett-server-url <url>",
 			"DEPRECATED: Your Jackett server url",
 			fileConfig.jackettServerUrl
 		)
-		.requiredOption(
+		.option(
 			"-k, --jackett-api-key <key>",
 			"DEPRECATED: Your Jackett API key",
 			fileConfig.jackettApiKey
 		)
-		.requiredOption(
+		.option(
 			"-t, --trackers <tracker1>,<tracker2>",
 			"DEPRECATED: Comma-separated list of Jackett tracker ids to search  (Tracker ids can be found in their Torznab feed paths)",
 			fallback(fileConfig.trackers?.join(","), "")
 		)
-		.requiredOption(
+		.option(
 			"-T, --torznab <urls...>",
 			"Torznab urls with apikey included (separated by spaces)",
 			fallback(fileConfig.torznab)

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -2,62 +2,104 @@
 // it here as a default.
 
 module.exports = {
+	/**
+	 * @deprecated use torznab instead
+	 */
 	jackettServerUrl: "http://localhost:9117/jackett",
+
+	/**
+	 * @deprecated use torznab instead
+	 */
 	jackettApiKey: "YOUR_JACKETT_API_KEY_HERE",
 
-	// Pause at least this much in between each Jackett search. Higher is safer.
-	// It is not recommended to set this to less than 2 seconds.
+	/**
+	 * Pause at least this much in between each Jackett search. Higher is safer.
+	 * 	It is not recommended to set this to less than 2 seconds.
+	 */
 	delay: 10,
 
-	// Trackers to search
-	// Set to [] if you want to search all trackers.
-	// Tracker ids can be found in their Torznab feed paths
+	/**
+	 * @deprecated use torznab instead
+	 * Trackers to search
+	 * Set to [] if you want to search all trackers.
+	 * Tracker ids can be found in their Torznab feed paths
+	 */
 	trackers: ["oink", "tehconnection"],
 
-	// directory containing torrent files.
-	// For rtorrent, this is your session directory
-	// as configured in your .rtorrent.rc file.
-	// For deluge, this is ~/.config/deluge/state.
+	/**
+	 * List of Torznab urls.
+	 * The path should end in /api
+	 * For Jackett, click "Copy RSS feed"
+	 * For Prowlarr, click (i) and copy the Torznab Url, then append "?apikey=YOUR_PROWLARR_API_KEY"
+	 */
+	torznab: [],
+
+	/**
+	 * directory containing torrent files.
+	 * For rtorrent, this is your session directory
+	 * as configured in your .rtorrent.rc file.
+	 * For deluge, this is ~/.config/deluge/state.
+	 */
 	torrentDir: "/path/to/torrent/file/dir",
 
-	// where to put the torrent files that cross-seed finds for you.
+	/**
+	 * where to put the torrent files that cross-seed finds for you.
+	 */
 	outputDir: ".",
 
-	// Whether to search for single episode torrents
+	/**
+	 * Whether to search for single episode torrents
+	 */
 	includeEpisodes: false,
 
-	// search for all torrents, regardless of their contents
-	// this option overrides includeEpisodes.
+	/**
+	 * search for all torrents, regardless of their contents
+	 * this option overrides includeEpisodes.
+	 */
 	searchAll: false,
 
-	// fuzzy size match threshold
-	// decimal value (0.02 = 2%)
+	/**
+	 * fuzzy size match threshold
+	 * decimal value (0.02 = 2%)
+	 */
 	fuzzySizeThreshold: 0.02,
 
-	// Exclude torrents first seen more than n minutes ago.
+	/**
+	 * Exclude torrents first seen more than n minutes ago.
+	 */
 	excludeOlder: undefined,
 
-	// Exclude torrents which have been searched
-	// more recently than n minutes ago.
+	/**
+	 * Exclude torrents which have been searched
+	 * more recently than n minutes ago.
+	 */
 	excludeRecentSearch: undefined,
 
-	// can be either "save" or "inject".
-	// With "inject" you need to set up one of the below clients.
+	/**
+	 * can be either "save" or "inject".
+	 * With "inject" you need to set up one of the below clients.
+ 	 */
 	action: "save",
 
-	// The url of your rtorrent XMLRPC interface.
-	// Only relevant with action: "inject".
-	// Could be something like "http://username:password@localhost:1234/RPC2
+	/**
+	 * The url of your rtorrent XMLRPC interface.
+	 * Only relevant with action: "inject".
+	 * Could be something like "http://username:password@localhost:1234/RPC2
+	 */
 	rtorrentRpcUrl: undefined,
 
-	// The url of your qBittorrent webui.
-	// Only relevant with action: "inject".
-	// Supply your username and password inside the url like so:
-	// "http://username:password@localhost:8080"
+	/**
+	 * The url of your qBittorrent webui.
+	 * Only relevant with action: "inject".
+	 * Supply your username and password inside the url like so:
+	 * "http://username:password@localhost:8080"
+	 */
 	qbittorrentUrl: undefined,
 
-	// cross-seed will send POST requests to this url
-	// with a JSON payload of { title, body }.
-	// Conforms to the caronc/apprise REST API.
+	/**
+	 * cross-seed will send POST requests to this url
+	 * with a JSON payload of { title, body }.
+	 * Conforms to the caronc/apprise REST API.
+	 */
 	notificationWebhookUrl: undefined,
 };

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -2,66 +2,107 @@
 // it here as a default.
 
 module.exports = {
-	jackettServerUrl: "http://jackett:9117/jackett",
+	/**
+	 * @deprecated use torznab instead
+	 */
+	jackettServerUrl: "http://localhost:9117/jackett",
+
+	/**
+	 * @deprecated use torznab instead
+	 */
 	jackettApiKey: "YOUR_JACKETT_API_KEY_HERE",
 
-	// Pause at least this much in between each Jackett search. Higher is safer.
-	// It is not recommended to set this to less than 2 seconds.
+	/**
+	 * Pause at least this much in between each Jackett search. Higher is safer.
+	 * 	It is not recommended to set this to less than 2 seconds.
+	 */
 	delay: 10,
 
-	// Trackers to search
-	// Set to [] if you want to search all trackers.
-	// Tracker ids can be found in their Torznab feed paths
+	/**
+	 * @deprecated use torznab instead
+	 * Trackers to search
+	 * Set to [] if you want to search all trackers.
+	 * Tracker ids can be found in their Torznab feed paths
+	 */
 	trackers: ["oink", "tehconnection"],
 
-	// directory containing torrent files.
-	// For rtorrent, this is your session directory
-	// as configured in your .rtorrent.rc file.
-	// For deluge, this is ~/.config/deluge/state.
-	// Don't change this for Docker.
-	// Instead set the volume mapping on your docker container.
+	/**
+	 * List of Torznab urls.
+	 * For Jackett, click "Copy RSS feed"
+	 * For Prowlarr, click (i) and copy the Torznab Url, then append "?apikey=YOUR_PROWLARR_API_KEY"
+	 */
+	torznab: [],
+
+	/**
+	 * directory containing torrent files.
+	 * For rtorrent, this is your session directory
+	 * as configured in your .rtorrent.rc file.
+	 * For deluge, this is ~/.config/deluge/state.
+	 * Don't change this for Docker.
+	 * Instead set the volume mapping on your docker container.
+	 */
 	torrentDir: "/torrents",
 
-	// where to put the torrent files that cross-seed finds for you.
-	// Don't change this for Docker.
-	// Instead set the volume mapping on your docker container.
+	/**
+	 * where to put the torrent files that cross-seed finds for you.
+	 * Don't change this for Docker.
+	 * Instead set the volume mapping on your docker container.
+	 */
 	outputDir: "/cross-seeds",
 
-	// Whether to search for single episode torrents
+	/**
+	 * Whether to search for single episode torrents
+	 */
 	includeEpisodes: false,
 
-	// search for all torrents, regardless of their contents
-	// this option overrides includeEpisodes.
+	/**
+	 * search for all torrents, regardless of their contents
+	 * this option overrides includeEpisodes.
+	 */
 	searchAll: false,
 
-	// fuzzy size match threshold
-	// decimal value (0.02 = 2%)
+	/**
+	 * fuzzy size match threshold
+	 * decimal value (0.02 = 2%)
+	 */
 	fuzzySizeThreshold: 0.02,
 
-	// Exclude torrents first seen more than n minutes ago.
+	/**
+	 * Exclude torrents first seen more than n minutes ago.
+	 */
 	excludeOlder: undefined,
 
-	// Exclude torrents which have been searched
-	// more recently than n minutes ago.
+	/**
+	 * Exclude torrents which have been searched
+	 * more recently than n minutes ago.
+	 */
 	excludeRecentSearch: undefined,
 
-	// can be either "save" or "inject".
-	// With "inject" you need to set up one of the below clients.
+	/**
+	 * can be either "save" or "inject".
+	 * With "inject" you need to set up one of the below clients.
+	 */
 	action: "save",
 
-	// The url of your rtorrent XMLRPC interface.
-	// Only relevant with action: "inject".
-	// Could be something like "http://username:password@localhost:1234/RPC2
+	/**
+	 * The url of your rtorrent XMLRPC interface.
+	 * Only relevant with action: "inject".
+	 * Could be something like "http://username:password@localhost:1234/RPC2
+	 */
 	rtorrentRpcUrl: undefined,
 
-	// The url of your qBittorrent webui.
-	// Only relevant with action: "inject".
-	// Supply your username and password inside the url like so:
-	// "http://username:password@localhost:8080"
+	/**
+	 * The url of your qBittorrent webui.
+	 * Only relevant with action: "inject".
+	 * Supply your username and password inside the url like so:
+	 * "http://username:password@localhost:8080"
+	 */
 	qbittorrentUrl: undefined,
 
-	// cross-seed will send POST requests to this url
-	// with a JSON payload of { title, body }.
-	// Conforms to the caronc/apprise REST API.
+	/**
+	 * cross-seed will send POST requests to this url
+	 * with a JSON payload of { title, body }.
+	 * Conforms to the caronc/apprise REST API.
+ 	 */
 	notificationWebhookUrl: undefined,
 };

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -23,6 +23,7 @@ interface FileConfig {
 	excludeRecentSearch?: number;
 	torrentDir?: string;
 	trackers?: string[];
+	torznab?: string[];
 	qbittorrentUrl?: string;
 	notificationWebhookUrl?: string;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,9 +6,6 @@ export const MOVIE_REGEX =
 
 export const EXTENSIONS = ["mkv", "mp4", "avi"];
 
-export const CONFIG_TEMPLATE_URL =
-	"https://github.com/mmgoodnow/cross-seed/blob/master/src/config.template.js";
-
 export const TORRENT_CACHE_FOLDER = "torrent_cache";
 
 export enum Action {
@@ -31,9 +28,3 @@ export enum Decision {
 	INFO_HASH_ALREADY_EXISTS = "INFO_HASH_ALREADY_EXISTS",
 	FILE_TREE_MISMATCH = "FILE_TREE_MISMATCH",
 }
-
-export const PermanentDecisions: Decision[] = [
-	Decision.SIZE_MISMATCH,
-	Decision.NO_DOWNLOAD_LINK,
-	Decision.FILE_TREE_MISMATCH,
-];

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { appDir } from "./configuration.js";
 import { Decision, TORRENT_CACHE_FOLDER } from "./constants.js";
 import db, { DecisionEntry } from "./db.js";
-import { SearchResult } from "./jackett.js";
+import { SearchResult } from "./pipeline.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
@@ -156,7 +156,7 @@ async function assessResultCaching(
 	searchee: Searchee,
 	infoHashesToExclude: string[]
 ): Promise<ResultAssessment> {
-	const { guid, title, trackerId: tracker } = result;
+	const { guid, title, tracker } = result;
 	const logReason = createReasonLogger(title, tracker, searchee.name);
 
 	db.data.decisions[searchee.name] ??= {};

--- a/src/decide.ts
+++ b/src/decide.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { appDir } from "./configuration.js";
 import { Decision, TORRENT_CACHE_FOLDER } from "./constants.js";
 import db, { DecisionEntry } from "./db.js";
-import { JackettResult } from "./jackett.js";
+import { SearchResult } from "./jackett.js";
 import { Label, logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
@@ -77,17 +77,17 @@ function sizeDoesMatch(resultSize, searchee) {
 }
 
 async function assessResultHelper(
-	{ Link, Size }: JackettResult,
+	{ link, size }: SearchResult,
 	searchee: Searchee,
 	hashesToExclude: string[]
 ): Promise<ResultAssessment> {
-	if (!sizeDoesMatch(Size, searchee)) {
+	if (!sizeDoesMatch(size, searchee)) {
 		return { decision: Decision.SIZE_MISMATCH };
 	}
 
-	if (!Link) return { decision: Decision.NO_DOWNLOAD_LINK };
+	if (!link) return { decision: Decision.NO_DOWNLOAD_LINK };
 
-	const info = await parseTorrentFromURL(Link);
+	const info = await parseTorrentFromURL(link);
 
 	if (!info) return { decision: Decision.DOWNLOAD_FAILED };
 
@@ -126,7 +126,7 @@ function cacheTorrentFile(meta: Metafile): void {
 }
 
 async function assessAndSaveResults(
-	result: JackettResult,
+	result: SearchResult,
 	searchee: Searchee,
 	Guid: string,
 	infoHashesToExclude: string[]
@@ -152,15 +152,15 @@ async function assessAndSaveResults(
 }
 
 async function assessResultCaching(
-	result: JackettResult,
+	result: SearchResult,
 	searchee: Searchee,
 	infoHashesToExclude: string[]
 ): Promise<ResultAssessment> {
-	const { Guid, Title, TrackerId: tracker } = result;
-	const logReason = createReasonLogger(Title, tracker, searchee.name);
+	const { guid, title, trackerId: tracker } = result;
+	const logReason = createReasonLogger(title, tracker, searchee.name);
 
 	db.data.decisions[searchee.name] ??= {};
-	const cacheEntry: DecisionEntry = db.data.decisions[searchee.name][Guid];
+	const cacheEntry: DecisionEntry = db.data.decisions[searchee.name][guid];
 
 	let assessment: ResultAssessment;
 
@@ -171,7 +171,7 @@ async function assessResultCaching(
 		assessment = await assessAndSaveResults(
 			result,
 			searchee,
-			Guid,
+			guid,
 			infoHashesToExclude
 		);
 		logReason(assessment.decision, false);
@@ -181,7 +181,7 @@ async function assessResultCaching(
 	) {
 		// has been added since the last run
 		assessment = { decision: Decision.INFO_HASH_ALREADY_EXISTS };
-		db.data.decisions[searchee.name][Guid].decision =
+		db.data.decisions[searchee.name][guid].decision =
 			Decision.INFO_HASH_ALREADY_EXISTS;
 	} else if (
 		cacheEntry.decision === Decision.MATCH &&
@@ -196,7 +196,7 @@ async function assessResultCaching(
 		assessment = await assessAndSaveResults(
 			result,
 			searchee,
-			Guid,
+			guid,
 			infoHashesToExclude
 		);
 		logReason(assessment.decision, false);
@@ -205,7 +205,7 @@ async function assessResultCaching(
 		assessment = { decision: cacheEntry.decision };
 		logReason(cacheEntry.decision, true);
 	}
-	db.data.decisions[searchee.name][Guid].lastSeen = Date.now();
+	db.data.decisions[searchee.name][guid].lastSeen = Date.now();
 	db.write();
 	return assessment;
 }

--- a/src/jackett.ts
+++ b/src/jackett.ts
@@ -31,10 +31,20 @@ function fullJackettUrl(
 }
 
 export async function validateJackettApi(): Promise<void> {
-	const { jackettServerUrl, jackettApiKey: apikey } = getRuntimeConfig();
+	const {
+		jackettServerUrl,
+		jackettApiKey: apikey,
+		torznab,
+	} = getRuntimeConfig();
+
+	if (torznab) return;
+
+	logger.warn(
+		"Jackett-only mode is deprecated and will be removed in a future release. Please specify your trackers using Torznab urls."
+	);
 
 	if (/\/$/.test(jackettServerUrl)) {
-		logger.warn("Warning: Jackett server url should not end with '/'");
+		logger.warn("Jackett server url should not end with '/'");
 	}
 
 	// search for gibberish so the results will be empty

--- a/src/jackett.ts
+++ b/src/jackett.ts
@@ -3,18 +3,12 @@ import get from "simple-get";
 import { EP_REGEX, MOVIE_REGEX, SEASON_REGEX } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
 import { Label, logger } from "./logger.js";
+import { SearchResult } from "./pipeline.js";
 import {
 	EmptyNonceOptions,
 	getRuntimeConfig,
 	NonceOptions,
 } from "./runtimeConfig.js";
-
-export interface SearchResult {
-	guid: string;
-	link: string;
-	size: number;
-	title: string;
-}
 
 export interface OgJackettResult {
 	Guid: string;
@@ -45,7 +39,10 @@ function reformatTitleForSearching(name: string): string {
 		.trim();
 }
 
-function fullJackettUrl(jackettServerUrl: string, params) {
+function fullJackettUrl(
+	jackettServerUrl: string,
+	params: Record<string, string | string[]>
+) {
 	const jackettPath = `/api/v2.0/indexers/all/results`;
 	return `${jackettServerUrl}${jackettPath}?${querystring.encode(params)}`;
 }
@@ -73,6 +70,7 @@ function parseResponse(response: JackettResponse): SearchResult[] {
 		link: result.Link,
 		size: result.Size,
 		title: result.Title,
+		tracker: result.TrackerId,
 	}));
 }
 

--- a/src/jackett.ts
+++ b/src/jackett.ts
@@ -9,51 +9,23 @@ import {
 	NonceOptions,
 } from "./runtimeConfig.js";
 
-export interface JackettResult {
-	Author: unknown;
-	BlackholeLink: string;
-	BookTitle: unknown;
-	Category: number[];
-	CategoryDesc: string;
-	Description: unknown;
-	Details: string;
-	DownloadVolumeFactor: number;
-	Files: number;
-	FirstSeen: string;
-	Gain: number;
-	Grabs: number;
-	Guid: string;
-	Imdb: unknown;
-	InfoHash: unknown;
-	Link: string;
-	MagnetUri: unknown;
-	MinimumRatio: number;
-	MinimumSeedTime: number;
-	Peers: number;
-	Poster: unknown;
-	PublishDate: string;
-	RageID: unknown;
-	Seeders: number;
-	Size: number;
-	TMDb: unknown;
-	TVDBId: unknown;
-	Title: string;
-	Tracker: string;
-	TrackerId: string;
-	UploadVolumeFactor: number;
+export interface SearchResult {
+	guid: string;
+	link: string;
+	size: number;
+	title: string;
 }
 
-export interface JackettIndexer {
-	ID: string;
-	Name: string;
-	Status: number;
-	Results: number;
-	Error: string;
+export interface OgJackettResult {
+	Guid: string;
+	Link: string;
+	Size: number;
+	Title: string;
+	TrackerId: string;
 }
 
 export interface JackettResponse {
-	Results: JackettResult[];
-	Indexers: JackettIndexer[];
+	Results: OgJackettResult[];
 }
 
 function reformatTitleForSearching(name: string): string {
@@ -95,10 +67,19 @@ export async function validateJackettApi(): Promise<void> {
 	}
 }
 
+function parseResponse(response: JackettResponse): SearchResult[] {
+	return response.Results.map((result) => ({
+		guid: result.Guid,
+		link: result.Link,
+		size: result.Size,
+		title: result.Title,
+	}));
+}
+
 export function makeJackettRequest(
 	name: string,
 	nonceOptions: NonceOptions = EmptyNonceOptions
-): Promise<JackettResponse> {
+): Promise<SearchResult[]> {
 	const {
 		jackettApiKey,
 		trackers: runtimeConfigTrackers,
@@ -127,5 +108,5 @@ export function makeJackettRequest(
 			if (err) reject(err);
 			else resolve(data);
 		});
-	});
+	}).then(parseResponse);
 }

--- a/src/jackett.ts
+++ b/src/jackett.ts
@@ -40,7 +40,7 @@ export async function validateJackettApi(): Promise<void> {
 	// search for gibberish so the results will be empty
 	const gibberish = "bscdjpstabgdspjdasmomdsenqciadsnocdpsikncaodsnimcdqsanc";
 	try {
-		await makeJackettRequest(gibberish);
+		await searchJackett(gibberish);
 	} catch (e) {
 		const dummyUrl = fullJackettUrl(jackettServerUrl, { apikey });
 		throw new CrossSeedError(`Could not reach Jackett at ${dummyUrl}`);
@@ -57,7 +57,7 @@ function parseResponse(response: JackettResponse): SearchResult[] {
 	}));
 }
 
-export function makeJackettRequest(
+export function searchJackett(
 	name: string,
 	nonceOptions: NonceOptions = EmptyNonceOptions
 ): Promise<SearchResult[]> {

--- a/src/jackett.ts
+++ b/src/jackett.ts
@@ -1,6 +1,5 @@
 import querystring from "querystring";
 import get from "simple-get";
-import { EP_REGEX, MOVIE_REGEX, SEASON_REGEX } from "./constants.js";
 import { CrossSeedError } from "./errors.js";
 import { Label, logger } from "./logger.js";
 import { SearchResult } from "./pipeline.js";
@@ -9,6 +8,7 @@ import {
 	getRuntimeConfig,
 	NonceOptions,
 } from "./runtimeConfig.js";
+import { reformatTitleForSearching } from "./utils.js";
 
 export interface OgJackettResult {
 	Guid: string;
@@ -20,23 +20,6 @@ export interface OgJackettResult {
 
 export interface JackettResponse {
 	Results: OgJackettResult[];
-}
-
-function reformatTitleForSearching(name: string): string {
-	const seasonMatch = name.match(SEASON_REGEX);
-	const movieMatch = name.match(MOVIE_REGEX);
-	const episodeMatch = name.match(EP_REGEX);
-	const fullMatch = episodeMatch
-		? episodeMatch[0]
-		: seasonMatch
-		? seasonMatch[0]
-		: movieMatch
-		? movieMatch[0]
-		: name;
-	return fullMatch
-		.replace(/[.()[\]]/g, " ")
-		.replace(/\s+/g, " ")
-		.trim();
 }
 
 function fullJackettUrl(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -41,6 +41,7 @@ function redactMessage(message) {
 	const runtimeConfig = getRuntimeConfig();
 
 	message = message.split(runtimeConfig.jackettApiKey).join(redactionMsg);
+	message = message.replace(/apikey=[a-zA-Z0-9]+/g, `apikey=${redactionMsg}`);
 
 	for (const [key, urlStr] of Object.entries(runtimeConfig)) {
 		if (key.endsWith("Url") && urlStr) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -11,6 +11,7 @@ export enum Label {
 	PREFILTER = "prefilter",
 	CONFIGDUMP = "configdump",
 	JACKETT = "jackett",
+	TORZNAB = "torznab",
 	SERVER = "server",
 	STARTUP = "startup",
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -87,7 +87,7 @@ async function searchJackettOrTorznab(
 	nonceOptions: NonceOptions
 ): Promise<SearchResult[]> {
 	const { torznab } = getRuntimeConfig();
-	return torznab.length
+	return torznab
 		? searchTorznab(name, nonceOptions)
 		: searchJackett(name, nonceOptions);
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -110,7 +110,7 @@ async function findOnOtherSites(
 	try {
 		response = await searchJackettOrTorznab(query, nonceOptions);
 	} catch (e) {
-		logger.error(`error querying Jackett for ${query}`);
+		logger.error(`error searching for ${query}`);
 		return 0;
 	}
 	const results = response;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -82,7 +82,7 @@ async function performAction(
 	return { isTorrentIncomplete };
 }
 
-async function search(
+async function searchJackettOrTorznab(
 	name: string,
 	nonceOptions: NonceOptions
 ): Promise<SearchResult[]> {
@@ -108,7 +108,7 @@ async function findOnOtherSites(
 	const query = stripExtension(searchee.name);
 	let response: SearchResult[];
 	try {
-		response = await search(query, nonceOptions);
+		response = await searchJackettOrTorznab(query, nonceOptions);
 	} catch (e) {
 		logger.error(`error querying Jackett for ${query}`);
 		return 0;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -4,11 +4,7 @@ import { getClient } from "./clients/TorrentClient.js";
 import { Action, Decision, InjectionResult } from "./constants.js";
 import db from "./db.js";
 import { assessResult, ResultAssessment } from "./decide.js";
-import {
-	JackettResponse,
-	SearchResult,
-	makeJackettRequest,
-} from "./jackett.js";
+import { makeJackettRequest } from "./jackett.js";
 import { logger } from "./logger.js";
 import { filterByContent, filterDupes, filterTimestamps } from "./preFilter.js";
 import { pushNotifier } from "./pushNotifier.js";
@@ -19,11 +15,11 @@ import {
 } from "./runtimeConfig.js";
 import { Searchee } from "./searchee.js";
 import {
-	TorrentLocator,
 	getInfoHashesToExclude,
 	getTorrentByCriteria,
 	loadTorrentDirLight,
 	saveTorrentFile,
+	TorrentLocator,
 } from "./torrent.js";
 
 import { getTag, stripExtension } from "./utils.js";
@@ -33,6 +29,7 @@ export interface SearchResult {
 	link: string;
 	size: number;
 	title: string;
+	tracker: string;
 }
 
 interface AssessmentWithTracker {
@@ -51,7 +48,7 @@ async function findOnOtherSites(
 		result: SearchResult
 	): Promise<AssessmentWithTracker> => ({
 		assessment: await assessResult(result, searchee, hashesToExclude),
-		tracker: result.trackerId,
+		tracker: result.tracker,
 	});
 
 	const tag = getTag(searchee.name);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -21,7 +21,7 @@ import {
 	saveTorrentFile,
 	TorrentLocator,
 } from "./torrent.js";
-
+import { search } from "./torznab.js";
 import { getTag, stripExtension } from "./utils.js";
 
 export interface SearchResult {
@@ -55,6 +55,7 @@ async function findOnOtherSites(
 	const query = stripExtension(searchee.name);
 	let response: SearchResult[];
 	try {
+		await search(query, nonceOptions);
 		response = await makeJackettRequest(query, nonceOptions);
 	} catch (e) {
 		logger.error(`error querying Jackett for ${query}`);

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -22,11 +22,13 @@ interface RuntimeConfig {
 
 export interface NonceOptions {
 	trackers: string[];
+	torznab: string[];
 	outputDir: string;
 }
 
 export const EmptyNonceOptions = {
 	trackers: undefined,
+	torznab: undefined,
 	outputDir: undefined,
 };
 

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -5,6 +5,7 @@ interface RuntimeConfig {
 	jackettApiKey: string;
 	delay: number;
 	trackers: string[];
+	torznab: string[];
 	torrentDir: string;
 	outputDir: string;
 	includeEpisodes: boolean;

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -4,6 +4,7 @@ import { validateJackettApi } from "./jackett.js";
 import { logger } from "./logger.js";
 import { getRuntimeConfig } from "./runtimeConfig.js";
 import { validateTorrentDir } from "./torrent.js";
+import { validateTorznabUrls } from "./torznab.js";
 
 function validateOptions() {
 	const { action, rtorrentRpcUrl, qbittorrentUrl } = getRuntimeConfig();
@@ -21,6 +22,7 @@ export async function doStartupValidation(): Promise<void> {
 	await Promise.all<void>(
 		[
 			validateJackettApi(),
+			validateTorznabUrls(),
 			downloadClient?.validateConfig(),
 			validateTorrentDir(),
 		].filter(Boolean)

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -115,7 +115,9 @@ export async function searchTorznab(
 	const searchUrls = torznab.map((url) =>
 		assembleUrl(url, {
 			t: "search",
-			q: encodeURIComponent(reformatTitleForSearching(name)),
+			q: encodeURIComponent(reformatTitleForSearching(name))
+				.split("%20")
+				.join(" "),
 		})
 	);
 	searchUrls.forEach(

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -1,12 +1,11 @@
 import { zip } from "lodash-es";
 import fetch from "node-fetch";
-import Parser from "rss-parser";
-import { inspect } from "util";
 import xml2js from "xml2js";
 import { CrossSeedError } from "./errors.js";
-import { logger } from "./logger.js";
+import { Label, logger } from "./logger.js";
 import { SearchResult } from "./pipeline.js";
 import { getRuntimeConfig, NonceOptions } from "./runtimeConfig.js";
+import { reformatTitleForSearching } from "./utils.js";
 
 interface CustomFeed {
 	foo: string;
@@ -23,13 +22,6 @@ interface TorznabParams {
 	offset?: number;
 	apikey?: string;
 }
-
-const parser: Parser<CustomFeed, CustomItem> = new Parser({
-	customFields: {
-		feed: ["foo"],
-		item: ["size"],
-	},
-});
 
 export function assembleUrl(
 	srcUrl: string | URL,
@@ -75,14 +67,11 @@ export async function validateTorznabUrls() {
 			"yes"
 	);
 	unsupported
-		.map(
-			([url]) =>
-				`Disabling ${url} because it either is down or doesn't support searching`
-		)
+		.map(([url]) => `${url} is either down or doesn't support searching`)
 		.forEach(logger.warn);
 
 	if (unsupported.length > 0 && unsupported.length === responses.length) {
-		throw new CrossSeedError("no indexers enabled");
+		throw new CrossSeedError("no working indexers available");
 	}
 }
 
@@ -92,9 +81,62 @@ export async function fetchCaps(url: string | URL): Promise<any> {
 		.then(xml2js.parseStringPromise);
 }
 
+async function parse(text: string): Promise<SearchResult[]> {
+	const jsified = await xml2js.parseStringPromise(text);
+	const items = jsified?.rss?.channel?.[0]?.item;
+	if (!items || !Array.isArray(items)) {
+		return [];
+	}
+
+	return items.map((item) => ({
+		guid: item.guid[0],
+		title: item.title[0],
+		tracker:
+			item?.prowlarrindexer?.[0]?._ ??
+			item?.jackettindexer?.[0]?._ ??
+			item?.indexer?.[0]?._ ??
+			"Unknown tracker",
+		link: item.link[0],
+		size: Number(item.size[0]),
+	}));
+}
+
+function isFulfilled(
+	outcome: PromiseSettledResult<SearchResult[]>
+): outcome is PromiseFulfilledResult<SearchResult[]> {
+	return outcome.status === "fulfilled";
+}
+
 export async function search(
 	name: string,
 	nonceOptions: NonceOptions
 ): Promise<SearchResult[]> {
-	return [];
+	const { torznab } = getRuntimeConfig();
+	const searchUrls = torznab.map((url) =>
+		assembleUrl(url, { t: "search", q: reformatTitleForSearching(name) })
+	);
+	searchUrls.forEach(
+		(message) => void logger.verbose({ label: Label.TORZNAB, message })
+	);
+	const outcomes = await Promise.allSettled(
+		searchUrls.map((url) =>
+			fetch(url)
+				.then((r) => r.text())
+				.then(parse)
+		)
+	);
+	const rejected = zip(torznab, outcomes).filter(
+		([, outcome]) => outcome.status === "rejected"
+	);
+	rejected
+		.map(
+			([url, outcome]) =>
+				`Failed searching ${url} for ${name} with reason: ${outcome.reason}`
+		)
+		.forEach(logger.warn);
+
+	const fulfilled = outcomes
+		.filter(isFulfilled)
+		.map((outcome) => outcome.value);
+	return [].concat(...fulfilled);
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -113,7 +113,10 @@ export async function searchTorznab(
 ): Promise<SearchResult[]> {
 	const { torznab } = getRuntimeConfig();
 	const searchUrls = torznab.map((url) =>
-		assembleUrl(url, { t: "search", q: reformatTitleForSearching(name) })
+		assembleUrl(url, {
+			t: "search",
+			q: encodeURIComponent(reformatTitleForSearching(name)),
+		})
 	);
 	searchUrls.forEach(
 		(message) => void logger.verbose({ label: Label.TORZNAB, message })

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -7,14 +7,6 @@ import { SearchResult } from "./pipeline.js";
 import { getRuntimeConfig, NonceOptions } from "./runtimeConfig.js";
 import { reformatTitleForSearching } from "./utils.js";
 
-interface CustomFeed {
-	foo: string;
-}
-
-interface CustomItem {
-	size: number;
-}
-
 interface TorznabParams {
 	t: "caps" | "search";
 	q?: string;
@@ -43,6 +35,8 @@ export function assembleUrl(
 
 export async function validateTorznabUrls() {
 	const { torznab } = getRuntimeConfig();
+	if (!torznab) return;
+
 	const urls: URL[] = torznab.map((str) => new URL(str));
 	for (const url of urls) {
 		if (!url.pathname.endsWith("/api")) {

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -5,7 +5,8 @@ import { inspect } from "util";
 import xml2js from "xml2js";
 import { CrossSeedError } from "./errors.js";
 import { logger } from "./logger.js";
-import { getRuntimeConfig } from "./runtimeConfig.js";
+import { SearchResult } from "./pipeline.js";
+import { getRuntimeConfig, NonceOptions } from "./runtimeConfig.js";
 
 interface CustomFeed {
 	foo: string;
@@ -80,11 +81,20 @@ export async function validateTorznabUrls() {
 		)
 		.forEach(logger.warn);
 
-	throw new CrossSeedError("kill");
+	if (unsupported.length > 0 && unsupported.length === responses.length) {
+		throw new CrossSeedError("no indexers enabled");
+	}
 }
 
 export async function fetchCaps(url: string | URL): Promise<any> {
 	return fetch(assembleUrl(url, { t: "caps" }))
 		.then((r) => r.text())
 		.then(xml2js.parseStringPromise);
+}
+
+export async function search(
+	name: string,
+	nonceOptions: NonceOptions
+): Promise<SearchResult[]> {
+	return [];
 }

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -1,0 +1,71 @@
+import fetch from "node-fetch";
+import Parser from "rss-parser";
+import { CrossSeedError } from "./errors.js";
+import { getRuntimeConfig } from "./runtimeConfig.js";
+
+interface CustomFeed {
+	foo: string;
+}
+
+interface CustomItem {
+	size: number;
+}
+
+interface TorznabParams {
+	t: "caps" | "search";
+	q?: string;
+	limit?: number;
+	offset?: number;
+	apikey?: string;
+}
+
+const parser: Parser<CustomFeed, CustomItem> = new Parser({
+	customFields: {
+		feed: ["foo"],
+		item: ["size"],
+	},
+});
+
+export function assembleUrl(
+	srcUrl: string | URL,
+	params: TorznabParams
+): string {
+	const url = new URL(srcUrl);
+	const apikey = url.searchParams.get("apikey");
+	const searchParams = new URLSearchParams();
+
+	searchParams.set("apikey", apikey);
+
+	for (const [key, value] of Object.entries(params)) {
+		if (value != null) searchParams.set(key, value);
+	}
+
+	url.search = searchParams.toString();
+	console.log(url.toString());
+	return url.toString();
+}
+
+export async function validateTorznabUrls() {
+	const { torznab } = getRuntimeConfig();
+	const urls: URL[] = torznab.map((str) => new URL(str));
+	for (const url of urls) {
+		if (!url.pathname.endsWith("/api")) {
+			throw new CrossSeedError(
+				`Torznab url ${url} must have a path ending in /api`
+			);
+		}
+		if (!url.searchParams.has("apikey")) {
+			throw new CrossSeedError(
+				`Torznab url ${url} does not specify an apikey`
+			);
+		}
+	}
+
+	const responses = await Promise.all(urls.map((url) => fetchCaps(url)));
+	console.log(responses);
+	throw new CrossSeedError("kill");
+}
+
+export async function fetchCaps(url: string | URL) {
+	return fetch(assembleUrl(url, { t: "caps" })).then((r) => r.text());
+}

--- a/src/torznab.ts
+++ b/src/torznab.ts
@@ -107,7 +107,7 @@ function isFulfilled(
 	return outcome.status === "fulfilled";
 }
 
-export async function search(
+export async function searchTorznab(
 	name: string,
 	nonceOptions: NonceOptions
 ): Promise<SearchResult[]> {
@@ -118,7 +118,7 @@ export async function search(
 	searchUrls.forEach(
 		(message) => void logger.verbose({ label: Label.TORZNAB, message })
 	);
-	const outcomes = await Promise.allSettled(
+	const outcomes = await Promise.allSettled<SearchResult[]>(
 		searchUrls.map((url) =>
 			fetch(url)
 				.then((r) => r.text())

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,3 +36,15 @@ export function getTag(name: string): string {
 export type Result<T> = T | Error;
 
 export const ok = <T>(r: Result<T>): r is T => !(r instanceof Error);
+
+export function reformatTitleForSearching(name: string): string {
+	const seasonMatch = name.match(SEASON_REGEX);
+	const movieMatch = name.match(MOVIE_REGEX);
+	const episodeMatch = name.match(EP_REGEX);
+	const fullMatch =
+		episodeMatch?.[0] ?? seasonMatch?.[0] ?? movieMatch?.[0] ?? name;
+	return fullMatch
+		.replace(/[.()[\]]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}


### PR DESCRIPTION
Closes #83 
Sort of unblocks #13

- [x] config file
- [x] cli args
- [x] deprecate jackett config options
- [x] ping all indexers on startup (is this necessary? Maybe it's just slowing things down with minimal benefit)
- [x] Standardize on a TS representation of a result
- [x] Parse RSS into said representation
- [ ] ~~Paging~~ actually we're gonna just pretend paging doesn't exist. Prowlarr defaults to 100 and jackett seems to just be unpaged, and 100 results for a query on a private tracker would be pretty high
- [x] abstract searching pipeline to work either in jackett or torznab mode
- [x] disable jackett mode if torznab is specified
- [ ] ~~handle nonce options supplied in real-time requests to the daemon~~ descoped, as I'm not sure anybody uses this feature. Will reconsider if I hear from someone
- [x] update README
- [x] deprecation logging for jackett mode 
- [x] remove/relax jackett startup validation and required options
- [x] proper urlencoding
- [x] fix redaction