### PR TITLE
Respect includeEpisodes even when searchAll is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
   -T, --torznab <urls...>               Torznab urls with apikey included (separated by spaces)
   -i, --torrent-dir <dir>               Directory with torrent files
   -s, --output-dir <dir>                Directory to save results in
-  -a, --search-all                      Search for all torrents regardless of their contents (default: false)
+  --include-non-videos                    Include torrents which contain non-video files (default: false)
   -e, --include-episodes                Include single-episode torrents in the search (default: false)
   --fuzzy-size-threshold <decimal>      The size difference allowed to be considered a match. (default: 0.02)
   -v, --verbose                         Log verbose output (default: false)

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -84,7 +84,7 @@ function createCommandWithSharedOptions(name, description) {
 		)
 		.requiredOption(
 			"-a, --search-all",
-			"Search for all torrents regardless of their contents",
+			"Search for all torrents regardless of their contents. Respects -e. To search everything except episodes, use -a. To search everything including episodes, use -ae",
 			fallback(fileConfig.searchAll, false)
 		)
 		.option(

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -83,9 +83,9 @@ function createCommandWithSharedOptions(name, description) {
 			fileConfig.outputDir
 		)
 		.requiredOption(
-			"-a, --search-all",
-			"Search for all torrents regardless of their contents. Respects -e. To search everything except episodes, use -a. To search everything including episodes, use -ae",
-			fallback(fileConfig.searchAll, false)
+			"--include-non-videos",
+			"Include torrents which contain non-video files",
+			fallback(fileConfig.includeNonVideos, false)
 		)
 		.option(
 			"-e, --include-episodes",

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -54,7 +54,9 @@ module.exports = {
 
 	/**
 	 * search for all torrents, regardless of their contents
-	 * this option overrides includeEpisodes.
+	 * This option does not override includeEpisodes.
+	 * To search for everything except episodes, use (includeEpisodes: false, searchAll: true)
+	 * To search for everything including episodes, use (includeEpisodes: true, searchAll: true)
 	 */
 	searchAll: false,
 

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -53,12 +53,12 @@ module.exports = {
 	includeEpisodes: false,
 
 	/**
-	 * search for all torrents, regardless of their contents
+	 * Include torrents which contain non-video files
 	 * This option does not override includeEpisodes.
-	 * To search for everything except episodes, use (includeEpisodes: false, searchAll: true)
-	 * To search for everything including episodes, use (includeEpisodes: true, searchAll: true)
+	 * To search for everything except episodes, use (includeEpisodes: false, includeNonVideos: true)
+	 * To search for everything including episodes, use (includeEpisodes: true, includeNonVideos: true)
 	 */
-	searchAll: false,
+	includeNonVideos: false,
 
 	/**
 	 * fuzzy size match threshold

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -56,12 +56,12 @@ module.exports = {
 	includeEpisodes: false,
 
 	/**
-	 * search for all torrents, regardless of their contents
+	 * Include torrents which contain non-video files
 	 * This option does not override includeEpisodes.
-	 * To search for everything except episodes, use (includeEpisodes: false, searchAll: true)
-	 * To search for everything including episodes, use (includeEpisodes: true, searchAll: true)
+	 * To search for everything except episodes, use (includeEpisodes: false, includeNonVideos: true)
+	 * To search for everything including episodes, use (includeEpisodes: true, includeNonVideos: true)
 	 */
-	searchAll: false,
+	includeNonVideos: false,
 
 	/**
 	 * fuzzy size match threshold

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -57,7 +57,9 @@ module.exports = {
 
 	/**
 	 * search for all torrents, regardless of their contents
-	 * this option overrides includeEpisodes.
+	 * This option does not override includeEpisodes.
+	 * To search for everything except episodes, use (includeEpisodes: false, searchAll: true)
+	 * To search for everything including episodes, use (includeEpisodes: true, searchAll: true)
 	 */
 	searchAll: false,
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,7 +17,7 @@ interface FileConfig {
 	jackettServerUrl?: string;
 	outputDir?: string;
 	rtorrentRpcUrl?: string;
-	searchAll?: boolean;
+	includeNonVideos?: boolean;
 	fuzzySizeThreshold?: number;
 	excludeOlder?: number;
 	excludeRecentSearch?: number;

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -12,8 +12,6 @@ const extensionsWithDots = EXTENSIONS.map((e) => `.${e}`);
 export function filterByContent(searchee: Searchee): boolean {
 	const { includeEpisodes, includeNonVideos } = getRuntimeConfig();
 
-	if (includeNonVideos && includeEpisodes) return true;
-
 	function logReason(reason): void {
 		logger.verbose({
 			label: Label.PREFILTER,
@@ -21,22 +19,19 @@ export function filterByContent(searchee: Searchee): boolean {
 		});
 	}
 
-	if (
-		!includeEpisodes &&
-		searchee.files.length === 1 &&
-		EP_REGEX.test(searchee.files[0].name)
-	) {
+	const isSingleEpisodeTorrent =
+		searchee.files.length === 1 && EP_REGEX.test(searchee.files[0].name);
+
+	if (!includeEpisodes && isSingleEpisodeTorrent) {
 		logReason("it is a single episode");
 		return false;
 	}
 
-	if (includeNonVideos) return true;
-
-	const allVideos = searchee.files.every((file) =>
+	const allFilesAreVideos = searchee.files.every((file) =>
 		extensionsWithDots.includes(path.extname(file.name))
 	);
 
-	if (!allVideos) {
+	if (!includeNonVideos && !allFilesAreVideos) {
 		logReason("not all files are videos");
 		return false;
 	}

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -10,9 +10,9 @@ import { nMinutesAgo } from "./utils.js";
 const extensionsWithDots = EXTENSIONS.map((e) => `.${e}`);
 
 export function filterByContent(searchee: Searchee): boolean {
-	const { includeEpisodes, searchAll } = getRuntimeConfig();
+	const { includeEpisodes, includeNonVideos } = getRuntimeConfig();
 
-	if (searchAll && includeEpisodes) return true;
+	if (includeNonVideos && includeEpisodes) return true;
 
 	function logReason(reason): void {
 		logger.verbose({
@@ -30,7 +30,7 @@ export function filterByContent(searchee: Searchee): boolean {
 		return false;
 	}
 
-	if (searchAll) return true;
+	if (includeNonVideos) return true;
 
 	const allVideos = searchee.files.every((file) =>
 		extensionsWithDots.includes(path.extname(file.name))

--- a/src/preFilter.ts
+++ b/src/preFilter.ts
@@ -12,7 +12,7 @@ const extensionsWithDots = EXTENSIONS.map((e) => `.${e}`);
 export function filterByContent(searchee: Searchee): boolean {
 	const { includeEpisodes, searchAll } = getRuntimeConfig();
 
-	if (searchAll) return true;
+	if (searchAll && includeEpisodes) return true;
 
 	function logReason(reason): void {
 		logger.verbose({
@@ -29,6 +29,8 @@ export function filterByContent(searchee: Searchee): boolean {
 		logReason("it is a single episode");
 		return false;
 	}
+
+	if (searchAll) return true;
 
 	const allVideos = searchee.files.every((file) =>
 		extensionsWithDots.includes(path.extname(file.name))

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -9,7 +9,7 @@ export interface RuntimeConfig {
 	outputDir: string;
 	includeEpisodes: boolean;
 	verbose: boolean;
-	searchAll: boolean;
+	includeNonVideos: boolean;
 	fuzzySizeThreshold: number;
 	excludeOlder: number;
 	excludeRecentSearch: number;


### PR DESCRIPTION
This PR changes to respecting the includeEpisodes flag even when searchAll is true.

I believe that this would be a useful change for two reasons
1. It exclusively adds functionality without removing it. It is still possible to regain the old functionality by using both searchAll and includeEpisodes. But there is a new option, searchAll without includeEpisodes, which was impossible before
2. Using searchAll without includeEpisodes is very useful. Including episodes takes far too long when you automate downloading new content, but without searchAll many legitimately cross-seedable torrents are skipped by the filter. For example, out of about 10,000 torrents searched, roughly on the order of 10% of them were not episodes but were filtered out when searchAll was false, even though matches were found when searchAll was set to true. Among these were some of the largest torrents in the library (ones over 1TB), which are arguable the most beneficial to cross-seed.

Related discussion: https://github.com/mmgoodnow/cross-seed/discussions/91