### PR TITLE
Fix sonarr category issue

### DIFF
--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -263,6 +263,7 @@ export default class QBittorrent implements TorrentClient {
 		newTorrent: Metafile,
 		searchee: Searchee
 	): Promise<InjectionResult> {
+		const { duplicateCategories } = getRuntimeConfig();
 		if (await this.isInfoHashInClient(newTorrent.infoHash)) {
 			return InjectionResult.ALREADY_EXISTS;
 		}
@@ -274,7 +275,10 @@ export default class QBittorrent implements TorrentClient {
 			const { save_path, isComplete, autoTMM, category } =
 				await this.getTorrentConfiguration(searchee);
 
-			const newCategoryName = await this.setUpCrossSeedCategory(category);
+			const newCategoryName = duplicateCategories
+				? await this.setUpCrossSeedCategory(category)
+				: category;
+
 			if (!isComplete) return InjectionResult.TORRENT_NOT_COMPLETE;
 
 			const shouldManuallyEnforceContentLayout =

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -170,6 +170,7 @@ export default class QBittorrent implements TorrentClient {
 
 	async setUpCrossSeedCategory(ogCategoryName: string): Promise<string> {
 		if (!ogCategoryName) return "";
+		if (!ogCategoryName.endsWith(".cross-seed")) return ogCategoryName;
 
 		const categoriesStr = await this.request("/torrents/categories", "");
 		const categories: Record<string, Category> = JSON.parse(categoriesStr);

--- a/src/clients/QBittorrent.ts
+++ b/src/clients/QBittorrent.ts
@@ -170,7 +170,7 @@ export default class QBittorrent implements TorrentClient {
 
 	async setUpCrossSeedCategory(ogCategoryName: string): Promise<string> {
 		if (!ogCategoryName) return "";
-		if (!ogCategoryName.endsWith(".cross-seed")) return ogCategoryName;
+		if (ogCategoryName.endsWith(".cross-seed")) return ogCategoryName;
 
 		const categoriesStr = await this.request("/torrents/categories", "");
 		const categories: Record<string, Category> = JSON.parse(categoriesStr);

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -119,6 +119,11 @@ function createCommandWithSharedOptions(name, description) {
 			fileConfig.qbittorrentUrl
 		)
 		.option(
+			"--duplicate-categories",
+			"Create and inject using categories with the same save paths as your normal categories",
+			fileConfig.duplicateCategories
+		)
+		.option(
 			"--notification-webhook-url <url>",
 			"cross-seed will send POST requests to this url with a JSON payload of { title, body }",
 			fileConfig.notificationWebhookUrl

--- a/src/config.template.cjs
+++ b/src/config.template.cjs
@@ -89,6 +89,14 @@ module.exports = {
 	qbittorrentUrl: undefined,
 
 	/**
+	 * qBittorrent-specific
+	 * Whether to inject using categories with the same save paths as your normal categories.
+	 * Example: if you have a category called "Movies",
+	 * this will automatically inject cross-seeds to "Movies.cross-seed"
+	 */
+	duplicateCategories: false,
+
+	/**
 	 * cross-seed will send POST requests to this url
 	 * with a JSON payload of { title, body }.
 	 * Conforms to the caronc/apprise REST API.

--- a/src/config.template.docker.cjs
+++ b/src/config.template.docker.cjs
@@ -94,6 +94,15 @@ module.exports = {
 	qbittorrentUrl: undefined,
 
 	/**
+	 * qBittorrent-specific
+	 * Whether to inject using categories with the same save paths as your normal categories.
+	 * Example: if you have a category called "Movies",
+	 * this will automatically inject cross-seeds to "Movies.cross-seed"
+	 */
+	duplicateCategories: false,
+
+
+	/**
 	 * cross-seed will send POST requests to this url
 	 * with a JSON payload of { title, body }.
 	 * Conforms to the caronc/apprise REST API.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -22,6 +22,7 @@ interface FileConfig {
 	torrentDir?: string;
 	torznab?: string[];
 	qbittorrentUrl?: string;
+	duplicateCategories?: boolean;
 	notificationWebhookUrl?: string;
 	port?: number;
 	searchCadence?: string;

--- a/src/runtimeConfig.ts
+++ b/src/runtimeConfig.ts
@@ -14,6 +14,7 @@ export interface RuntimeConfig {
 	action: Action;
 	rtorrentRpcUrl: string;
 	qbittorrentUrl: string;
+	duplicateCategories: boolean;
 	notificationWebhookUrl: string;
 	torrents: string[];
 	port: number;


### PR DESCRIPTION
Closes #254

Behavior: 
- Sets up a category with the same savePath as the source torrent, but appends `.cross-seed` to the original category name.
- If the source torrent doesn't have a category, the injected torrent will also be uncategorized.