### PR TITLE
Send 204 if no match for announce POST

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -156,12 +156,15 @@ async function announce(
 	try {
 		await indexNewTorrents();
 		const result = await checkNewCandidateMatch(candidate);
-		if (result) {
-			logger.info({
-				label: Label.SERVER,
-				message: `Added announce from ${candidate.tracker}: ${candidate.name}`,
-			});
+		if (!result) {
+			res.writeHead(204);
+			res.end();
+			return;
 		}
+		logger.info({
+			label: Label.SERVER,
+			message: `Added announce from ${candidate.tracker}: ${candidate.name}`,
+		});
 		res.setHeader("Content-Type", "application/json");
 		res.writeHead(200);
 		res.end(JSON.stringify(result));

--- a/website/docs/reference/api.md
+++ b/website/docs/reference/api.md
@@ -66,7 +66,8 @@ off if you set up this feature.
 
 :::
 
-This endpoint returns 200 if your request was received.
+This endpoint returns 200 if your request was received and a match was found. If
+no match it responds with 204 No Content.
 
 ### Supported formats
 


### PR DESCRIPTION
Per discussion on Discord.

This changes the behavior for the `/announce` endpoint. 

Before: Send 200 OK on post with data if a match.
Now: Send 200 OK with data if match, and 204 No content if no match.

Why: to be able to easily use [autobrr](https://github.com/autobrr/autobrr) external filter to run cross-seed check early on.